### PR TITLE
use the same base image in CLI and sconification API

### DIFF
--- a/cli/templates/withProtectedData/javascript/Dockerfile
+++ b/cli/templates/withProtectedData/javascript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine3.11
+FROM node:14.4.0-alpine3.11
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci

--- a/cli/templates/withoutProtectedData/javascript/Dockerfile
+++ b/cli/templates/withoutProtectedData/javascript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine3.11
+FROM node:14.4.0-alpine3.11
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci


### PR DESCRIPTION
The JS template uses the docker base image `node:14-alpine3.11` while the API use `node:14.4.0-alpine3.11` for sconification.
`node:14` being the latest release of node v14, it is not equivalent to `node:14.4.0`
This can lead to having code working when executing with `idapp test --docker` to fail after sconificaton when running `idapp run <address>` (which is hard to debug).
This happened to me when using the JS feature [private class method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties#javascript.classes.private_class_methods) which was introduced in `node:14.6.0` hence is included in `node:14-alpine3.11` but not in `node:14.4.0-alpine3.11`

After this fix the code will fail locally (before sconification) giving developers a better understanding of what goes wrong