### PR TITLE
Use node --env-file instead of dotenv

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -17,4 +17,4 @@ COPY /src ./src
 EXPOSE 3000
 
 # Start the app
-CMD ["node", "src/index.js"]
+CMD ["node", "--env-file=.env", "src/index.js"]

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "cls-hooked": "^4.2.2",
         "dockerode": "^4.0.2",
-        "dotenv": "^16.4.5",
         "ethers": "^6.13.4",
         "express": "^5.0.1",
         "iexec": "^8.12.0",
@@ -908,18 +907,6 @@
       },
       "engines": {
         "node": ">= 8.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.6",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.6.tgz",
-      "integrity": "sha512-JhcR/+KIjkkjiU8yEpaB/USlzVi3i5whwOjpIRNGi9svKEXZSe+Qp6IWAjFjv+2GViAoDRCUv/QLNziQxsLqDg==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/api/package.json
+++ b/api/package.json
@@ -4,16 +4,15 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "node ./src/index.js",
-    "dev": "node --watch ./src/index.js",
-    "dev:pretty": "node --watch ./src/index.js | pino-pretty -tc",
+    "start": "node --env-file=.env ./src/index.js",
+    "dev": "node --env-file=.env --watch ./src/index.js",
+    "dev:pretty": "node --env-file=.env --watch ./src/index.js | pino-pretty -tc",
     "check-format": "prettier --check .",
     "format": "prettier --write ."
   },
   "dependencies": {
     "cls-hooked": "^4.2.2",
     "dockerode": "^4.0.2",
-    "dotenv": "^16.4.5",    
     "ethers": "^6.13.4",
     "express": "^5.0.1",
     "iexec": "^8.12.0",
@@ -24,7 +23,7 @@
   },
   "devDependencies": {
     "@types/cls-hooked": "^4.3.9",
-    "pino-pretty": "^13.0.0",    
+    "pino-pretty": "^13.0.0",
     "prettier": "^3.3.3"
   }
 }

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import express from 'express';
 import { readFile } from 'fs/promises';
 import pino from 'pino';


### PR DESCRIPTION
(since we're using node >20.6)